### PR TITLE
docs(README.md): add scope and status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Libs SDK (experimental)
+# Libs SDK
+[![Falco Ecosystem Repository](https://github.com/falcosecurity/evolution/blob/main/repos/badges/falco-ecosystem-blue.svg)](https://github.com/falcosecurity/evolution/blob/main/REPOSITORIES.md#ecosystem-scope) [![Sandbox](https://img.shields.io/badge/status-sandbox-red?style=for-the-badge)](https://github.com/falcosecurity/evolution/blob/main/REPOSITORIES.md#sandbox)
 
 A simplified API (a.k.a. facade) for [Falco Libs](https://github.com/falcosecurity/libs) in Golang.
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR introduces the [scope](https://github.com/falcosecurity/evolution/blob/main/REPOSITORIES.md#scope) and [status](https://github.com/falcosecurity/evolution/blob/main/REPOSITORIES.md#status) badges. See https://github.com/falcosecurity/evolution/issues/271 for more details.

Note: While adding the badges, I've noticed this repo does not match the criteria for the _incubating_ status, so I've added the badge for the sandbox.  I'll update its status on the evolution repository soon.